### PR TITLE
Clarify who needs to use the binder link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The example we follow is adapted from the [Intro-Jupyter tutorial from ICESat-2H
 
 ## Notebooks
 - UBC Students & Faculty can run on Syzygy: [![Syzygy](https://img.shields.io/badge/launch-syzygy-important)](https://ubc.syzygy.ca/jupyter/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flheagy%2ubc-jupyterdays-2020-widgets&urlpath=tree%2Fubc-jupyterdays-2020-widgets%2F&branch=master)
-- or if you don't have a UBC CWL you can use: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lheagy/ubc-jupyterdays-2020-widgets/master)
+- or if you don't have a UBC CWL with full Syzygy access (the "basic" accounts non-UBC personnel can use to register for the event aren't sufficient) you can use: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/lheagy/ubc-jupyterdays-2020-widgets/master)
 
 ## Motivating example: Climate Change
 


### PR DESCRIPTION
The syzygy one is restricted to "full" accounts.